### PR TITLE
Give the template package a version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools, versioneer
 #
 # Replace values below with what's appropriate for your package:
 
-name               = 'my-package'
+name               = 'pds.template.package'
 description        = 'A short description, about 100–120 characters'
 keywords           = ['pds', 'planetary data', 'various', 'other', 'keywords']
 zip_safe           = True


### PR DESCRIPTION
The Roundup's [ArtifactPublicationStep](https://github.com/NASA-PDS/roundup-action/blob/master/src/pds/roundup/_python.py#L151) was failing because this template repository didn't have a discernible release tag. We couldn't figure out the version.
