### PR TITLE
Issue #21 - Move install to setup.cfg and pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools >= 46.4.0", "wheel"]
+
+# uncomment to enable pep517 after versioneer problem is fixed.
+# https://github.com/python-versioneer/python-versioneer/issues/193
+#build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-sphinx
-sphinx-rtd-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,45 @@
+[metadata]
+name = your_package_name
+author = PDS
+author_email = pds_operator@jpl.nasa.gov
+description = A short description, about 100-120 characters, suitable for search summaries
+long_description = file: README.md
+license = apache-2.0
+keywords = pds, planetary data, various, other, keywords
+url = https://github.com/NASA-PDS/<TODO: complete URL>
+download_url = https://github.com/NASA-PDS/<TODO: complete URL>/releases/
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+
+
+[options]
+#install_requires =
+    # Put your requirements here
+zip_safe = True
+include_package_data = True
+namespace_packages = pds
+# base directory for code is in src/. Don't change this.
+package_dir =
+    = src
+packages = find:
+python_requires = >= 3.6
+
+[options.extras_require]
+dev =
+    sphinx
+    sphinx-rtd-theme
+
+[options.entry_points]
+# Put your entry point scripts here
+#console_scripts =
+    # some_script: ...
+
+[options.packages.find]
+# Don't change this. Needed to find packages under src/
+where=src
+
 [test]
 
 [install]
@@ -9,11 +51,3 @@ tag_prefix         = v
 versionfile_source = src/pds/my_pds_module/_version.py
 versionfile_build  = pds/my_pds_module/_version.py
 parentdir_prefix   = pds.my_pds_module-
-
-
-# For future consideration:
-#
-# - Move declarative metadata out of `setup.py` and into here
-# - Add `[options]` for zip-safe use, package metadata
-# - Both `requirements.txt` and `install_requires` violates DRY but I'm out of time
-

--- a/setup.py
+++ b/setup.py
@@ -1,64 +1,7 @@
-# -*- coding: utf-8 -*-
-
-import setuptools, versioneer
-
-
-# Package Metadata
-# ----------------
-#
-# Replace values below with what's appropriate for your package:
-
-name               = 'pds.template.package'
-description        = 'A short description, about 100–120 characters, suitable for search summaries'
-keywords           = ['pds', 'planetary data', 'various', 'other', 'keywords']
-zip_safe           = True
-namespace_packages = ['pds']
-extras_require     = {}
-entry_points       = {}
-
-
-# You can find the vocabulary for these at https://pypi.org/classifiers/
-classifiers = [
-    'Programming Language :: Python :: 3',
-    'License :: OSI Approved :: Apache Software License',
-    'Operating System :: OS Independent',
-]
-
-# Below here, you shouldn't have to change anything:
-
-with open('README.md', 'r') as fh:
-    long_description = fh.read()
-
-with open('requirements.txt', 'r') as f:
-    pip_requirements = f.readlines()
-
+import setuptools
+import versioneer
 
 setuptools.setup(
-    name=name,
     version=versioneer.get_version(),
-    license='apache-2.0',  # There's almost no standardization about what goes here, even amongst ALv2 projects
-    author='PDS',
-    author_email='pds_operator@jpl.nasa.gov',
-    description=description,
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/NASA-PDS/' + name,
-    download_url='https://github.com/NASA-PDS/' + name + '/releases/',
-    packages=setuptools.find_packages('src'),
-    include_package_data=True,
-    zip_safe=zip_safe,
-    namespace_packages=namespace_packages,
-    package_dir={'': 'src'},
-    keywords=keywords,
-    classifiers=classifiers,
-    python_requires='>=3.6',
-    install_requires=pip_requirements,
-    entry_points=entry_points,
-    extras_require=extras_require,
-    cmdclass=versioneer.get_cmdclass()
+    cmdclass=versioneer.get_cmdclass(),
 )
-
-
-# For future consideration:
-#
-# - `setup.py` metadata passé; move to `setup.cfg`


### PR DESCRIPTION
Move template repo over to setup.cfg for package metadata management and
pyproject.toml for up-to-date build system management. Development
dependencies are now grouped under `extras_require.dev` and
`requirements.txt` has been dropped.

Resolve #21

**Test Data and/or Report**
Tested install with a number of clean virtual environments. Verified "test suite" runs when installed via `pip install .` and `pip install -e .[dev]`. Verified that docs are buildable after `pip install -e .[dev]`. Installs look to be cooperating with these changes.

```
(pds-template-repo-python) > $ pip list                                                                                                                                                            [±main ✓]
Package                       Version                                                             Location
----------------------------- ------------------------------------------------------------------- ------------------------------------------------------
alabaster                     0.7.12
Babel                         2.9.1
certifi                       2021.5.30
charset-normalizer            2.0.4
docutils                      0.16
idna                          3.2
imagesize                     1.2.0
Jinja2                        3.0.1
MarkupSafe                    2.0.1
packaging                     21.0
pip                           21.2.2
Pygments                      2.9.0
pyparsing                     2.4.7
pytz                          2021.1
requests                      2.26.0
setuptools                    52.0.0.post20210125
snowballstemmer               2.1.0
Sphinx                        4.1.2
sphinx-rtd-theme              0.5.2
sphinxcontrib-applehelp       1.0.2
sphinxcontrib-devhelp         1.0.2
sphinxcontrib-htmlhelp        2.0.0
sphinxcontrib-jsmath          1.0.1
sphinxcontrib-qthelp          1.0.3
sphinxcontrib-serializinghtml 1.1.5
urllib3                       1.26.6
wheel                         0.36.2
your-package-name             1.0.0+48.ga2dbe7b.2.gd59698f.4.ge20cd11.2.g7f71a0b.3.g59171cd.dirty /Users/mjjoyce/Coding/PDS/pds-template-repo-python/src
```
