### PR TITLE
Partial resolution for NASA-PDS/roundup-action#47

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -53,6 +53,17 @@ jobs:
                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
                     fetch-depth: 0
             -
+                name: 💵 Python Cache
+                uses: actions/cache@v2
+                with:
+                    path: ~/.cache/pip
+                    # The "key" used to indicate a set of cached files is the operating system runner
+                    # plus "py" for Python-specific builds, plus a hash of the wheels, plus "pds" because
+                    # we pds-prefix everything with "pds" in PDS! 😅
+                    key: pds-${{runner.os}}-py-${{hashFiles('**/*.whl')}}
+                    # To restore a set of files, we only need to match a prefix of the saved key.
+                    restore-keys: pds-${{runner.os}}-py-
+            -
                 name: 🤠 Roundup
                 uses: NASA-PDS/roundup-action@main
                 with:

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -56,6 +56,17 @@ jobs:
                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
                     fetch-depth: 0
             -
+                name: 💵 Python Cache
+                uses: actions/cache@v2
+                with:
+                    path: ~/.cache/pip
+                    # The "key" used to indicate a set of cached files is the operating system runner
+                    # plus "py" for Python-specific builds, plus a hash of the wheels, plus "pds" because
+                    # we pds-prefix everything with "pds" in PDS! 😅
+                    key: pds-${{runner.os}}-py-${{hashFiles('**/*.whl')}}
+                    # To restore a set of files, we only need to match a prefix of the saved key.
+                    restore-keys: pds-${{runner.os}}-py-
+            -
                 name: 🤠 Roundup
                 uses: NASA-PDS/roundup-action@main
                 with:


### PR DESCRIPTION
## 📜 Summary

Merge this if you dare to resolve the Python part of NASA-PDS/roundup-action#47, which adds GitHub Actions caching for downloaded Maven dependencies (jar files and other artifacts).

## 🩺 Test Data and/or Report

Gonna sound like a broken record here: There's really no way to test this without a massive test harness (which would include—amongst many other things—the GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, image registries, OSSRH stub, PyPI stub, robots.txt to prevent dev sites crawling, warning banners, etc.).

## 🧩 Related Issues

- NASA-PDS/roundup-action#47