### PR TITLE
Set default required Python version to >= 3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ namespace_packages = pds
 package_dir =
     = src
 packages = find:
-python_requires = >= 3.6
+python_requires = >= 3.9
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Resolve #28
