### PR TITLE
Update README with Community Health file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@ To execute, run:
 
     (put your run commands here)
 
+## Code of Conduct
+
+All users and developers of the NASA-PDS software are expected to abide by our [Code of Conduct](https://github.com/NASA-PDS/.github/blob/main/CODE_OF_CONDUCT.md). Please read this to ensure you understand the expectations of our community.
 
 ## Development
 
 To develop this project, use your favorite text editor, or an integrated development environment with Python support, such as [PyCharm](https://www.jetbrains.com/pycharm/).
+
+### Contributing
+
+For information on how to contribute to NASA-PDS codebases please take a look at our [Contributing guidelines](https://github.com/NASA-PDS/.github/blob/main/CONTRIBUTING.md).
 
 ### Installation
 


### PR DESCRIPTION
Add sections to the README pointing people to our Code of Conduct and
Contributing community health files defined in NASA-PDS/.github. This
should help with the visibility problems raised in NASA-PDS/.github#7.

Resolve #36