### PR TITLE
Fix failing tox execution due to missing versioneer package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 46.4.0", "wheel"]
+requires = ["setuptools >= 46.4.0", "wheel", "versioneer-518"]
 
 # uncomment to enable pep517 after versioneer problem is fixed.
 # https://github.com/python-versioneer/python-versioneer/issues/193


### PR DESCRIPTION
Update the build-system requirements in pyproject.toml to include the
versioneer "shim" that works around the pip changes here that break
this. See the following ticket on the versioneer repo for additional
details.

    https://github.com/python-versioneer/python-versioneer/issues/193

Resolve #40

