### PR TITLE
Update core pre-commit linting steps to use local dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,23 +16,29 @@ repos:
     -   id: reorder-python-imports
         files: ^src/|tests/
 
--   repo: https://github.com/pre-commit/mirrors-mypy.git
-    rev: v0.910
+-   repo: local
     hooks:
     -   id: mypy
-        files: ^src/|tests/
+        name: mypy
+        entry: mypy src
+        language: system
+        pass_filenames: false
 
--   repo: https://github.com/python/black
-    rev: 21.7b0
+-   repo: local
     hooks:
     -   id: black
+        name: black
+        entry: black
         files: ^src/|tests/
+        language: system
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: local
     hooks:
     -   id: flake8
-        files: ^src/|tests/
+        name: flake8
+        entry: flake8 src
+        language: system
+        pass_filenames: false
 
 -   repo: local
     hooks:


### PR DESCRIPTION
Update pre-commit config so black, mypy, and flake8 run `local`
dependencies instead of using their own virtual environment. This
addresses the issue raised in #43 with additional dependencies for checks
being duplicated across `setup.cfg` and `.pre-commit-config.yaml`.

Update `mypy` and `flake8` calls to explicitly check `src` instead of
being passed individual file names to validate. For `mypy` this ensures
that we're doing a complete scan that is identical to a CLI call. For
`flake8` this just keeps our code quality nagging to the core code.

Resolve #43