### PR TITLE
Document Roundup handling of builds on "fresh" repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,6 @@ Or publish on testpypi (you need a testpypi account and configure `$HOME/.pypirc
 
     pip install twine
     twine upload --repository testpypi dist/*
+
+## CI/CD
+The template repository comes with our two "standard" CI/CD workflows, `stable-cicd` and `unstable-cicd`. The unstable build runs on any push to `main` (+/- ignoring changes to specific files) and the stable build runs on push of a release branch of the form `release/<release version>`. Both of these make use of our GitHub actions build step, [Roundup](https://github.com/NASA-PDS/roundup-action). The `unstable-cicd` will generate (and constantly update) a SNAPSHOT release. If you haven't done a formal software release you will end up with a `v0.0.0-SNAPSHOT` release (see NASA-PDS/roundup-action#56 for specifics).


### PR DESCRIPTION
Add a section describing the included CI/CD workflows and the
idiosyncrasies around builds on repositories without existing tags
from which to extract new version numbers.

Resolve #47
