### PR TITLE
Update black pre-commit config so execution is limited to Python files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
         entry: black
         files: ^src/|tests/
         language: system
+        types: [python]
 
 -   repo: local
     hooks:


### PR DESCRIPTION
No associated ticket for this. Extremely minor config update so that `black` is limited to running on Python files. We aren't really interested in it reformatting our READMEs or XML files.
