### PR TITLE
Add Google Analytics 4 tracking to Sphinx documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
+    'sphinx_rtd_theme',
+    'sphinxcontrib.googleanalytics',
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -84,3 +86,7 @@ html_theme_options = {
     'includehidden': True,
     'titles_only': False
 }
+
+# Google Analytics 4 (GA4) tracking
+googleanalytics_id = "G-Q1K210DS5W"
+googleanalytics_enabled = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ dev =
     pre-commit~=3.3.3
     sphinx~=8.2.3
     sphinx-rtd-theme~=3.0.2
+    sphinxcontrib-googleanalytics~=0.5
     tox~=4.11.0
     types-setuptools~=68.1.0.0
 


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
- Added sphinxcontrib.googleanalytics extension to docs configuration
- Configured GA4 tracking with ID G-Q1K210DS5W
- Updated Sphinx to v8.2.3 for Python 3.13 compatibility
- Updated sphinx-rtd-theme to v3.0.2
- Added sphinxcontrib-googleanalytics v0.5 to dev dependencies in setup.cfg
- Verified tracking code is present in all generated HTML pages

## ⚙️ Test Data and/or Report
See tox run

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
- Related to NASA-PDS/software-issues-repo#139