### PR TITLE
Add Issue Template examples to template repo

### DIFF
--- a/.github/ISSUE_TEMPLATE_example/-bug_report.yml.template
+++ b/.github/ISSUE_TEMPLATE_example/-bug_report.yml.template
@@ -1,0 +1,96 @@
+name: Bug report
+description: Report a bug to help us improve
+title: <system feature> <is not/does not> <expected behaviour>
+labels: "bug,needs:triage"
+type: "Bug"
+
+body:
+  - type: dropdown
+    id: checked-for-duplicates
+    attributes:
+      label: Checked for duplicates
+      description: Have you checked for duplicate issue tickets?
+      multiple: false
+      options:
+        - "No - I haven't checked"
+        - "Yes - I've already checked"
+    validations:
+      required: yes
+  - type: textarea
+    id: description
+    attributes:
+      label: 🐛 Describe the bug
+      description: A clear and concise description of what the bug is. Plain-text snippets and/or screenshots welcome.
+      placeholder: Tell us what you saw
+      value: "When I did [...] action, I noticed [...]"
+    validations:
+      required: true
+ 
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 🕵️ Expected behavior
+      description: A clear and concise description of what you expected to happen
+      placeholder: Tell us what you expected
+      value: "I expected [...]"
+    validations:
+      required: true
+ 
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 📜 To Reproduce
+      description: "How would we reproduce this bug? Please walk us through it step by step. Plain-text snippets and/or screenshots welcome."
+      value: |
+        1.
+        2.
+        3.
+        ...
+ 
+  - type: textarea
+    id: environment
+    attributes:
+      label: 🖥 Environment Info
+      description: "What is your environment? Include any computer hardware, operating system, framework, browser, time-of-day or other contextual information related to your issue"
+      value: |
+        - Version of this software [e.g. vX.Y.Z]
+        - Operating System: [e.g. MacOSX with Docker Desktop vX.Y]
+        ...
+
+  - type: textarea
+    id: version
+    attributes:
+      label: 📚 Version of Software Used
+      description: Command-line tools should have a `-V` or `--version` flag to get this information.
+
+  - type: textarea
+    id: test_data
+    attributes:
+      label: 🩺 Test Data / Additional context
+      description: "If not provided already, upload some test data. Note: May need to create a ZIP/TAR if the files are not compatible with GitHub."
+
+  - type: textarea
+    id: requirements
+    attributes:
+       label: 🦄 Related requirements
+       description: If known, provide links to the requirements/user stories applicable to this bug.
+       value: "🦄 #xyz"
+
+  - type: markdown
+    attributes:
+      value: |
+        ## For Internal Dev Team To Complete
+
+  - type: textarea
+    id: details
+    attributes:
+       label: ⚙️ Engineering Details
+
+  - type: textarea
+    id: i-n-t
+    attributes:
+      label: 🎉 Integration & Test
+      description: To be filled out by Engineering Node Team
+      placeholder:  Provide testing information and/or trace to TestRail ID
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE_example/-feature_request.yml.template
+++ b/.github/ISSUE_TEMPLATE_example/-feature_request.yml.template
@@ -1,0 +1,83 @@
+name: Feature request
+description: Suggest a new idea or new requirement for this project
+title: As a <what is the user's role?>, I want to <what is the user trying to accomplish?>
+labels: "needs:triage,requirement"
+type: "Feature"
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > _Thanks for filing a new feature request. We appreciate your time and effort. Please answer a few questions. For more information on how to populate this new feature request, see the PDS Wiki on User Story Development: https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#user-story-development_
+  - type: dropdown
+    id: checked-for-duplicates
+    attributes:
+      label: Checked for duplicates
+      description: Have you checked for duplicate issue tickets?
+      multiple: false
+      options:
+        - "No - I haven't checked"
+        - "Yes - I've already checked"
+    validations:
+      required: yes
+      
+  - type: textarea
+    id: personas
+    attributes:
+      label: 🧑‍🔬 User Persona(s)
+      description: What specific types of users to you think this feature applies to?
+      placeholder: Node Operator, Data Engineer, Data User, etc.
+    validations:
+      required: false
+      
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 💪 Motivation
+      description: Why? Finish the user story in the title.
+      value: "...so that I can [why do you want to do this?]"
+    validations:
+      required: false
+      
+  - type: textarea
+    id: details
+    attributes:
+      label: 📖 Additional Details
+      description: Provide any additional details, related problems, or information that could help provide some context for the user story.
+    validations:
+      required: false
+      
+  - type: markdown
+    attributes:
+      value: |
+        ## For Internal Dev Team To Complete
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: To be filled out by Engineering Node Team
+      value: |
+          **Given** <!-- a condition -->
+          **When I perform** <!-- an action -->
+          **Then I expect** <!-- the result -->
+    validations:
+      required: false
+      
+  - type: textarea
+    id: engineering-details
+    attributes:
+      label: ⚙️ Engineering Details
+      description: To be filled out by Engineering Node Team
+      placeholder:  Provide some design / implementation details and/or a sub-task checklist as needed. Convert issue to Epic if estimate is outside the scope of 1 sprint.
+    validations:
+      required: false
+
+  - type: textarea
+    id: i-n-t
+    attributes:
+      label: 🎉 I&T
+      description: To be filled out by Engineering Node Team
+      placeholder:  Provide testing information and/or trace to TestRail ID
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE_example/-vulnerability-issue.yml.template
+++ b/.github/ISSUE_TEMPLATE_example/-vulnerability-issue.yml.template
@@ -1,0 +1,91 @@
+name: Vulnerability Issue
+description: Describe security vulnerability
+title: "[SECURITY] <system feature> <is not/does not> <expected behaviour>"
+labels: "bug,needs:triage"
+type: "Bug"
+projects: "NASA-PDS/6"
+assignees: jordanpadams
+
+body:
+  - type: dropdown
+    id: checked-for-duplicates
+    attributes:
+      label: Checked for duplicates
+      description: Have you checked for duplicate issue tickets?
+      multiple: false
+      options:
+        - "Yes - I've already checked"
+        - "No - I haven't checked"
+    validations:
+      required: yes
+  - type: textarea
+    id: description
+    attributes:
+      label: 🐛 Describe the vulnerability
+      description: Describe the vulnerability or link to the Code scanning / Dependabot issues
+      placeholder: Tell us what you saw
+      value: "When I did [...] action, I noticed [...]"
+    validations:
+      required: true
+ 
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 🕵️ Expected behavior
+      description: A clear and concise description of what you expected to happen
+      placeholder: Tell us what you expected
+      value: "I expected [...]"
+    validations:
+      required: true
+ 
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 📜 To Reproduce
+      description: "How would we reproduce this bug? Please walk us through it step by step. Plain-text snippets and/or screenshots welcome."
+      value: |
+        1.
+        2.
+        3.
+        ...
+      render: bash
+ 
+  - type: textarea
+    id: environment
+    attributes:
+      label: 🖥 Environment Info
+      description: "What is your environment? Include any computer hardware, operating system, framework, browser, time-of-day or other contextual information related to your issue"
+      value: |
+        - Version of this software [e.g. vX.Y.Z]
+        - Operating System: [e.g. MacOSX with Docker Desktop vX.Y]
+        ...
+      render: bash
+
+  - type: textarea
+    id: version
+    attributes:
+      label: 📚 Version of Software Used
+      description: Command-line tools should have a `-V` or `--version` flag to get this information.
+
+  - type: textarea
+    id: test_data
+    attributes:
+      label: 🩺 Test Data / Additional context
+      description: "If not provided already, upload some test data. Note: May need to create a ZIP/TAR if the files are not compatible with GitHub."
+
+  - type: textarea
+    id: requirements
+    attributes:
+       label: 🦄 Related requirements
+       description: If known, provide links to the requirements/user stories applicable to this bug.
+       value: "🦄 #xyz"
+
+  - type: markdown
+    attributes:
+      value: |
+        ## For Internal Dev Team To Complete
+
+  - type: textarea
+    id: details
+    attributes:
+       label: ⚙️ Engineering Details

--- a/.github/ISSUE_TEMPLATE_example/config.yml
+++ b/.github/ISSUE_TEMPLATE_example/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PDS Help Desk
+    url: mailto:pds-operator@jpl.nasa.gov
+    about: Contact the PDS Help Desk with any additional questions you may have.

--- a/.github/ISSUE_TEMPLATE_example/task.yml.template
+++ b/.github/ISSUE_TEMPLATE_example/task.yml.template
@@ -1,0 +1,33 @@
+name: "[internal] Task"
+description: "Low level task or action that is often too granular for testing, but helps towards progress on an Epic or parent story"
+labels: "task"
+type: "Task"
+
+body:
+  - type: dropdown
+    id: check
+    attributes:
+      label: Are you sure this is not a new requirement or bug?
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true
+  - type: dropdown
+    id: task-type
+    attributes:
+      label: Task Type
+      description: If sub-task, be sure to select Epic (Parent issue in GitHub) from right panel after creation (Relationships -> Add Parent). If release theme, be sure to update label to be `theme` instead of `task`.
+      options:
+        - Sub-task
+        - Theme
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: 💡 Description
+      description: Enter description here. Make it detailed enough someone could actually know what you are doing, but if you spend too much time on this, it probably deserves it's own story.
+      placeholder: Tell us what is up
+    validations:
+      required: true

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,2 @@
+## Issue Templates
+To enable the issue templates, move `ISSUE_TEMPLATE_example` to `ISSUE_TEMPLATE`.


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
<!--
   Brief summary of changes if not sufficiently described by commit messages.
-->
Add template examples for non-Engineering Node repositories to avoid Engineering Node-isms being put on other repositories (e.g. default assignee is @jordanpadams)
